### PR TITLE
Add Total Step Configuration

### DIFF
--- a/train.py
+++ b/train.py
@@ -658,7 +658,11 @@ if __name__ == '__main__':
             if epoch is None:
                 break
 
-        saver.process_step(step)
+        should_quit = saver.process_step(step)
+        if should_quit:
+            saved = True
+            checkpointed = True
+            break
         step += 1
 
     # Save final training state checkpoint and model, unless we just saved them.

--- a/utils/saver.py
+++ b/utils/saver.py
@@ -165,7 +165,7 @@ class Saver:
         num_steps = self.config.get("num_steps", None)
         save_steps = self.config.get("save_every_n_steps", None)
 
-        if isinstance(num_steps, int) and step > num_steps:
+        if isinstance(num_steps, int) and step >= num_steps:
             print(f"Stopping training at user-requested step of {num_steps}")
             should_manually_save = True
             should_manually_quit = True
@@ -175,7 +175,7 @@ class Saver:
         if should_manually_save:
             self.save_model(f'step{step}')
 
-        if need_to_checkpoint(self.config) or should_manually_save:
+        if need_to_checkpoint(self.config):
             self.save_checkpoint(step)
 
         return should_manually_quit


### PR DESCRIPTION
To better control execution duration, many trainers use a maximum number of steps as this represents an amount of time that does not scale with the dataset size.

This change adds `num_steps` into the configuration as an optional value. During the `Saver` classes `process_step` method, there were stubs present for saving on step boundaries - this was expanded to accommodate this new configuration value.

A previous code path existed for calling `sys.exit()` directly in this saver method. This would be a pain to debug and I'm not fond of controlling execution outside of the main script, so this was removed in favor of returning a `should_quit` variable in `process_step`, then following the normal exit procedures.